### PR TITLE
静的モブヘッドをMobTypeで指定可能にする

### DIFF
--- a/src/main/kotlin/jp/awabi2048/cccontent/mob/type/EquipmentMobType.kt
+++ b/src/main/kotlin/jp/awabi2048/cccontent/mob/type/EquipmentMobType.kt
@@ -1,13 +1,17 @@
 package jp.awabi2048.cccontent.mob.type
 
+import com.destroystokyo.paper.profile.ProfileProperty
 import jp.awabi2048.cccontent.mob.CustomMobRuntime
 import jp.awabi2048.cccontent.mob.MobSpawnContext
 import jp.awabi2048.cccontent.mob.ability.MobAbility
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Slime
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.SkullMeta
+import java.util.UUID
 
 open class EquipmentMobType(
     id: String,
@@ -18,7 +22,8 @@ open class EquipmentMobType(
     private val defaultHelmet: Material? = null,
     private val defaultChestplate: Material? = null,
     private val defaultLeggings: Material? = null,
-    private val defaultBoots: Material? = null
+    private val defaultBoots: Material? = null,
+    private val defaultHelmetTexture: String? = null
 ) : AbilityMobType(
     id = id,
     baseEntityType = baseEntityType,
@@ -39,10 +44,26 @@ open class EquipmentMobType(
         if (offHand != null) {
             equipment.setItemInOffHand(ItemStack(offHand))
         }
-        val helmet = defaultHelmet
-        if (helmet != null) {
-            equipment.helmet = ItemStack(helmet)
+
+        val helmetTexture = defaultHelmetTexture
+        if (helmetTexture != null) {
+            val skull = ItemStack(Material.PLAYER_HEAD)
+            val skullMeta = skull.itemMeta as? SkullMeta
+            if (skullMeta != null) {
+                val profile = Bukkit.createProfile(UUID.randomUUID(), "cc_static_head")
+                profile.setProperty(ProfileProperty("textures", helmetTexture))
+                skullMeta.playerProfile = profile
+                skull.itemMeta = skullMeta
+            }
+            equipment.helmet = skull
+            equipment.helmetDropChance = 0.0f
+        } else {
+            val helmet = defaultHelmet
+            if (helmet != null) {
+                equipment.helmet = ItemStack(helmet)
+            }
         }
+
         val chestplate = defaultChestplate
         if (chestplate != null) {
             equipment.chestplate = ItemStack(chestplate)

--- a/src/main/kotlin/jp/awabi2048/cccontent/mob/type/MobTypes.kt
+++ b/src/main/kotlin/jp/awabi2048/cccontent/mob/type/MobTypes.kt
@@ -569,7 +569,8 @@ class SkeletonWeaponThrowCloseMobType : EquipmentMobType(
         WeaponThrowAbility(id = "skeleton_weapon_throw_close")
     ),
     defaultHelmet = Material.LEATHER_HELMET,
-    defaultChestplate = Material.CHAINMAIL_CHESTPLATE
+    defaultChestplate = Material.CHAINMAIL_CHESTPLATE,
+    defaultHelmetTexture = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTk3ZDYwMmIwYWYwNmU5MzRlYjQ2NDQyMzQ5ZTE1ZTFiOGQ1YWFmY2Q1ZmQ4Zjg2ZDc5NWNkNGVlOWNhMDY0ZSJ9fX0="
 ) {
     override fun applyDefaultEquipment(context: MobSpawnContext, runtime: CustomMobRuntime?) {
         super.applyDefaultEquipment(context, runtime)


### PR DESCRIPTION
## 概要
EquipmentMobType に optional な defaultHelmetTexture(String?) を追加し、指定時に PLAYER_HEAD に ProfileProperty("textures", ...) を設定してヘルメットに装備するようにしました。

## 変更点
- EquipmentMobType.kt: defaultHelmetTexture を追加、applyDefaultEquipment を修正
- MobTypes.kt: skeleton_throw_close に指定テクスチャを移動

## テスト
1. サーバー再起動後に skeleton_throw_close をスポーンして頭部が表示されること
2. 倒したときに頭がドロップしないこと
